### PR TITLE
fix exception handling for python version < 3.6

### DIFF
--- a/src/japronto/runner.py
+++ b/src/japronto/runner.py
@@ -6,6 +6,11 @@ import runpy
 
 from .app import Application
 
+try:
+    ModuleNotFoundError
+except NameError:
+    ModuleNotFoundError = ImportError
+
 
 def get_parser():
     prog = 'python -m japronto' if sys.argv[0].endswith('__main__.py') \
@@ -48,7 +53,7 @@ def verify(args):
 
         try:
             module = import_module(module)
-        except ImportError as e:
+        except ModuleNotFoundError as e:
             print(e.args[0] + ' on Python search path.')
             return False
 

--- a/src/japronto/runner.py
+++ b/src/japronto/runner.py
@@ -48,7 +48,7 @@ def verify(args):
 
         try:
             module = import_module(module)
-        except ModuleNotFoundError as e:
+        except ImportError as e:
             print(e.args[0] + ' on Python search path.')
             return False
 


### PR DESCRIPTION
**Use `ImportError` in place of `ModuleNotFoundError`**

- `ModuleNotFoundError` was introduced from Python 3.6
- To handle `import_module()` exceptions for Python version below 3.6, we can use `ImportError`
- `ImportError` is a subclass of `ModuleNotFoundError`

*Considering that this is meant to support Python 3.5 too*

reference: [https://docs.python.org/3/library/exceptions.html#ModuleNotFoundError](https://docs.python.org/3/library/exceptions.html#ModuleNotFoundError) 

Thanks and you've done a nice work on this project.