### PR TITLE
Change unnecessary string comparison to length check in Go benchmarks

### DIFF
--- a/benchmarks/golang-fasthttp/micro.go
+++ b/benchmarks/golang-fasthttp/micro.go
@@ -3,9 +3,8 @@ package main
 import "github.com/valyala/fasthttp"
 
 func hello(ctx *fasthttp.RequestCtx) {
-	if string(ctx.Path()) != "/" {
-		ctx.SetStatusCode(404)
-		ctx.WriteString("Not Found")
+	if len(ctx.Path()) != 1 {
+		ctx.Error("Not Found", fasthttp.StatusNotFound)
 		return
 	}
 	ctx.WriteString("Hello world!")

--- a/benchmarks/golang/micro.go
+++ b/benchmarks/golang/micro.go
@@ -8,9 +8,8 @@ var (
 )
 
 func hello(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
-		w.WriteHeader(http.StatusNotFound)
-		w.Write(notFoundResp)
+	if len(r.URL.Path) != 1 {
+		http.NotFound(w, r)
 		return
 	}
 	w.Write(helloResp)


### PR DESCRIPTION
Because router already guarantees that URL starts with '/', it's
unnecessary to compare the path string further for 404 check. One may as
well check that it's length matches expected one character.

Doesn't make huge difference on Go standard library version, but gives
couple thousand req/s more for fasthttp version.

Also made 404 response writing a cleaner, while at there.

I run my tests on idle Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz and got some interesting results. First, japronto benchmark results were about in line with your AWS results, but Go versions were noticeably faster - probably due to faster processor clock speed. I tested with Go 1.7.4 and 1.8.0rc3. From these, the stable version was noticeably faster for stdlib performance, but for fasthttp it was other way round. What's behind this, is not yet clear. Numbers are in the end. All tests were run with:

wrk -t 1 -c 100 -d 2m -s misc/pipeline.lua http://localhost:8080

With latest Go 1.8.0rc3 and my change, the golang-fasthttp version was ~1.195x faster than japronto.

japronto:
Requests/sec: 1249535.78
Transfer/sec:    109.63MB

Go before change:
Go 1.7.4:
stdlib:
Requests/sec: 100442.66
Transfer/sec:     12.36MB

fasthttp:
Requests/sec: 1429564.72
Transfer/sec:    200.41MB

Go 1.8.0rc3:
stdlib:
Requests/sec:  88058.14
Transfer/sec:     10.83MB

fasthttp:
Requests/sec: 1477820.61
Transfer/sec:    207.18MB

After this change:
Go 1.7.4:
stdlib:
Requests/sec: 101756.51
Transfer/sec:     12.52MB

fasthttp:
Requests/sec: 1468705.08
Transfer/sec:    205.90MB

Go 1.8.0rc3:
stdlib:
Requests/sec:  87261.03
Transfer/sec:     10.74MB

fasthttp:
Requests/sec: 1494392.48
Transfer/sec:    209.50MB