### PR TITLE
select slower path on older hardware

### DIFF
--- a/build.py
+++ b/build.py
@@ -261,8 +261,12 @@ class custom_build_ext(build_ext):
         compile_c(
             self.compiler,
             'src/picohttpparser/picohttpparser.c',
-            'src/picohttpparser/picohttpparser.o',
+            'src/picohttpparser/ssepicohttpparser.o',
             options={'unix': ['-msse4.2']})
+        compile_c(
+            self.compiler,
+            'src/picohttpparser/picohttpparser.c',
+            'src/picohttpparser/picohttpparser.o')
         build_ext.build_extensions(self)
 
 

--- a/src/japronto/cpu_features.c
+++ b/src/japronto/cpu_features.c
@@ -1,0 +1,16 @@
+#include <cpuid.h>
+#include <assert.h>
+
+#include "cpu_features.h"
+
+int supports_x86_sse42(void)
+{
+#if defined(__clang__)
+  unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+  __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+  return ecx & bit_SSE4_2;
+#else
+  __builtin_cpu_init();
+  return __builtin_cpu_supports("sse4.2");
+#endif
+}

--- a/src/japronto/cpu_features.h
+++ b/src/japronto/cpu_features.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int supports_x86_sse42(void);

--- a/src/japronto/parser/cparser.c
+++ b/src/japronto/parser/cparser.c
@@ -2,6 +2,7 @@
 #include <sys/param.h>
 
 #include "cparser.h"
+#include "cpu_features.h"
 
 #ifndef PARSER_STANDALONE
 #include "cprotocol.h"
@@ -744,9 +745,7 @@ int
 cparser_init(void)
 #endif
 {
-    __builtin_cpu_init();
-
-    if(__builtin_cpu_supports("sse4.2")) {
+    if(supports_x86_sse42()) {
       _phr_parse_request = phr_parse_request_sse42;
     } else {
       printf("Warning: Host CPU doesnt support SSE 4.2, selecting slower implementation");

--- a/src/japronto/parser/cparser.c
+++ b/src/japronto/parser/cparser.c
@@ -748,7 +748,7 @@ cparser_init(void)
     if(supports_x86_sse42()) {
       _phr_parse_request = phr_parse_request_sse42;
     } else {
-      printf("Warning: Host CPU doesnt support SSE 4.2, selecting slower implementation");
+      printf("Warning: Host CPU doesn't support SSE 4.2, selecting slower implementation\n");
       _phr_parse_request = phr_parse_request;
     }
 

--- a/src/japronto/parser/cparser_ext.py
+++ b/src/japronto/parser/cparser_ext.py
@@ -6,5 +6,7 @@ def get_extension():
         'japronto.parser.cparser',
         sources=['cparser.c'],
         include_dirs=['../../picohttpparser'],
-        extra_objects=['src/picohttpparser/picohttpparser.o'],
+        extra_objects=[
+            'src/picohttpparser/picohttpparser.o',
+            'src/picohttpparser/ssepicohttpparser.o'],
         define_macros=[('PARSER_STANDALONE', 1)])

--- a/src/japronto/parser/cparser_ext.py
+++ b/src/japronto/parser/cparser_ext.py
@@ -4,8 +4,8 @@ from distutils.core import Extension
 def get_extension():
     return Extension(
         'japronto.parser.cparser',
-        sources=['cparser.c'],
-        include_dirs=['../../picohttpparser'],
+        sources=['cparser.c', '../cpu_features.c'],
+        include_dirs=['../../picohttpparser', '..'],
         extra_objects=[
             'src/picohttpparser/picohttpparser.o',
             'src/picohttpparser/ssepicohttpparser.o'],

--- a/src/picohttpparser/picohttpparser.h
+++ b/src/picohttpparser/picohttpparser.h
@@ -53,12 +53,19 @@ struct phr_header {
 int phr_parse_request(const char *buf, size_t len, const char **method, size_t *method_len, const char **path, size_t *path_len,
                       int *minor_version, struct phr_header *headers, size_t *num_headers, size_t last_len);
 
+int phr_parse_request_sse42(const char *buf, size_t len, const char **method, size_t *method_len, const char **path, size_t *path_len,
+                      int *minor_version, struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+
 /* ditto */
+// squeaky_p: we don't use it yet
+#if 0
 int phr_parse_response(const char *_buf, size_t len, int *minor_version, int *status, const char **msg, size_t *msg_len,
                        struct phr_header *headers, size_t *num_headers, size_t last_len);
 
 /* ditto */
 int phr_parse_headers(const char *buf, size_t len, struct phr_header *headers, size_t *num_headers, size_t last_len);
+#endif
 
 /* should be zero-filled before start */
 struct phr_chunked_decoder {


### PR DESCRIPTION
Currently under older CPUs without SSE 4.2 Japronto explodes with SIGILL. This pull request makes build system compile two versions of parser and plugs them later according to the host CPU capabilities.