### PR TITLE
Use copy of sys.modules.items() to avoid runtime error in reloader

### DIFF
--- a/src/japronto/reloader.py
+++ b/src/japronto/reloader.py
@@ -53,7 +53,7 @@ def change_detector():
         changed = False
         current_mtimes = {}
 
-        for name, module in sys.modules.items():
+        for name, module in list(sys.modules.items()):
             try:
                 filename = module.__file__
             except AttributeError:


### PR DESCRIPTION
Been running into this every once and a while

``` 
 File ".../python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File ".../python3.5/site-packages/japronto/reloader.py", line 83, in run
    for changed in change_detector():
  File ".../python3.5/site-packages/japronto/reloader.py", line 56, in change_detector
    for name, module in sys.modules.items():
RuntimeError: dictionary changed size during iteration
```

Similar issue to https://github.com/cherrypy/cherrypy/issues/1280